### PR TITLE
Updating init() to use non-nullable calculatedProjectId

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ class MockIdToken extends Mock implements IdToken { }
 
 void main() {
   late FirebaseAuthValidator validator;
-  late IdToken token;
+  late idToken token;
 
   setUp(() {
     validator = MockFirebaseAuthValidator();

--- a/lib/src/validate_firebase_auth.dart
+++ b/lib/src/validate_firebase_auth.dart
@@ -72,7 +72,7 @@ class FirebaseAuthValidator {
           );
       final issuer =
           await Issuer.discover(Issuer.firebase(calculatedProjectId));
-      client = Client(issuer, projectId);
+      client = Client(issuer, projectId!);
     }
   }
 

--- a/lib/src/validate_firebase_auth.dart
+++ b/lib/src/validate_firebase_auth.dart
@@ -72,7 +72,7 @@ class FirebaseAuthValidator {
           );
       final issuer =
           await Issuer.discover(Issuer.firebase(calculatedProjectId));
-      client = Client(issuer, projectId!);
+      client = Client(issuer, calculatedProjectId);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -203,7 +203,7 @@ packages:
       name: openid_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.3"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   very_good_analysis: ^2.0.0
-  openid_client: ^0.4.1
+  openid_client: ^0.4.3
   http: ^0.13.3
   meta: ^1.4.0
 


### PR DESCRIPTION
## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

YES

## Description

I updated the init() function so that it passes the calculatedProjectId to the openid Client class. I also updated the openid_client package to the most recent version (0.4.3). And finally, I fixed a typo in the test example of the packages home page.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x ] 📝 Documentation
- [ ] 🗑️ Chore
